### PR TITLE
Replacing github,website links to npm links

### DIFF
--- a/src/pages/ecosystem.mdx
+++ b/src/pages/ecosystem.mdx
@@ -1,4 +1,5 @@
-export const description = 'Popular plugins and libraries to use in your React projects.'
+export const description =
+  'Popular plugins and libraries to use in your React projects.'
 
 # Ecosystem
 
@@ -10,31 +11,31 @@ Generally, to make our list below, the library in question needs to have support
 
 ## Hooks
 
-- [usehooks.com](https://usehooks.com/)
-- [usehooks-ts.com](https://usehooks-ts.com/)
+- [usehooks.com](https://www.npmjs.com/package/use-hooks)
+- [usehooks-ts.com](https://www.npmjs.com/package/usehooks-ts)
 
 ## Utility Libraries
 
 Utility libraries typically bring an array of functions at your disposal, either all around a single domain (such as dates/timezones) or more generic (array sorting, object cloning, deep comparisons, etc.)
 
-- [date-fns](https://date-fns.org/)
+- [date-fns](https://www.npmjs.com/package/date-fns)
 - [use-local-storage-state](https://www.npmjs.com/package/use-local-storage-state)
 - [react-cookie](https://www.npmjs.com/package/@shopify/react-cookie)
-- [lodash](https://lodash.com/)
+- [lodash](https://www.npmjs.com/package/lodash)
 
 ## Forms & Inputs
 
 The form libraries below can help you build complex forms, and the input components can bring non-standard browser input types (such as datepickers, multi-select dropdowns, etc.) into your application.
 
-- [react-hook-form](https://github.com/react-hook-form/react-hook-form)
-- [react-final-form](https://github.com/final-form/react-final-form)
+- [react-hook-form](https://www.npmjs.com/package/react-hook-form)
+- [react-final-form](https://www.npmjs.com/package/react-final-form)
 - [rc-field-form](https://www.npmjs.com/package/rc-field-form)
-- [formik](https://github.com/jaredpalmer/formik)
+- [formik](https://www.npmjs.com/package/formik)
 - We recommend [zod](https://www.npmjs.com/package/zod) or [yup](https://www.npmjs.com/package/yup) for form validation
 
 ### Form UI & Inputs
 
-For basic form elements like dropdowns, radio groups, checkboxes, we recommend [Radix](https://www.radix-ui.com/).
+For basic form elements like dropdowns, radio groups, checkboxes, we recommend [Radix](https://www.npmjs.com/package/@radix-ui/primitive).
 
 Input masking
 
@@ -44,13 +45,13 @@ Input masking
 
 Select / Multi-Select
 
-- [react-select](https://github.com/JedWatson/react-select)
+- [react-select](https://www.npmjs.com/package/react-select)
 - [rc-tree-select](https://www.npmjs.com/package/rc-tree-select)
 
 Datepickers
 
-- [react-dates](https://github.com/airbnb/react-dates)
-- [react-datepicker](https://github.com/Hacker0x01/react-datepicker/)
+- [react-dates](https://www.npmjs.com/package/react-dates)
+- [react-datepicker](https://www.npmjs.com/package/react-datepicker)
 - [react-calendar](https://www.npmjs.com/package/react-calendar)
 - [react-day-picker](https://www.npmjs.com/package/react-day-picker)
 
@@ -58,59 +59,59 @@ Datepickers
 
 Headless UI Libraries
 
-- [radix-ui](https://www.radix-ui.com/)
-- [headless-ui](https://headlessui.com/)
-- [react-aria](https://react-spectrum.adobe.com/react-aria/)
-- [reakit](https://reakit.io/)
+- [radix-ui](https://www.npmjs.com/package/@radix-ui/primitive)
+- [headless-ui](https://www.npmjs.com/package/@headlessui/react)
+- [react-aria](https://www.npmjs.com/package/react-aria)
+- [ariakit](https://www.npmjs.com/package/ariakit)
 
 Animations / Loading States
 
-- [framer/motion](https://github.com/framer/motion)
-- [react-spring](https://github.com/pmndrs/react-spring)
+- [framer/motion](https://www.npmjs.com/package/framer-motion)
+- [react-spring](https://www.npmjs.com/package/react-spring)
 - [react-loading-skeleton](https://www.npmjs.com/package/react-loading-skeleton)
 
 Drag & Drop / Resizing Elements / Drawing
 
-- [react-beautiful-dnd](https://github.com/atlassian/react-beautiful-dnd) - Beautiful and accessible drag and drop for lists with React
-- [react-dnd](https://github.com/react-dnd/react-dnd) - Drag and Drop for React
-- [react-draggable](https://github.com/mzabriskie/react-draggable) - React draggable component
-- [react-resizable](https://github.com/strml/react-resizable) - A simple React component that is resizable with a handle
-- [react-grid-layout](https://github.com/strml/react-grid-layout) - A draggable and resizable grid layout with responsive breakpoints
-- [react-advanced-cropper](https://github.com/Norserium/react-advanced-cropper) - An advanced React component for image cropping
-- [react-archer](https://github.com/pierpo/react-archer) - Draw arrows between React elements
+- [react-beautiful-dnd](https://www.npmjs.com/package/react-beautiful-dnd) - Beautiful and accessible drag and drop for lists with React
+- [react-dnd](https://www.npmjs.com/package/react-dnd) - Drag and Drop for React
+- [react-draggable](https://www.npmjs.com/package/react-draggable) - React draggable component
+- [react-resizable](https://www.npmjs.com/package/react-resizable) - A simple React component that is resizable with a handle
+- [react-grid-layout](https://www.npmjs.com/package/react-grid-layout) - A draggable and resizable grid layout with responsive breakpoints
+- [react-advanced-cropper](https://www.npmjs.com/package/react-advanced-cropper) - An advanced React component for image cropping
+- [react-archer](https://www.npmjs.com/package/react-archer) - Draw arrows between React elements
 
 Charts & Data Visualization
 
-- [vx](https://github.com/airbnb/visx) - Visualization components
-- [victory](https://github.com/FormidableLabs/victory) - A collection of composable React components for building interactive data visualizations
-- [react-vis](https://github.com/uber/react-vis) - Data Visualization Components
-- [recharts](https://github.com/recharts/recharts) - Redefined chart library built with React and D3
-- [nivo](https://github.com/plouc/nivo) - Provides a rich set of data visualization components, built on top of the D3 and React libraries
+- [vx](https://www.npmjs.com/org/visx) - Visualization components
+- [victory](https://npmjs.com/package/victory) - A collection of composable React components for building interactive data visualizations
+- [react-vis](https://npmjs.org/package/react-vis) - Data Visualization Components
+- [recharts](https://www.npmjs.com/package/recharts) - Redefined chart library built with React and D3
+- [nivo](https://www.npmjs.com/org/nivo) - Provides a rich set of data visualization components, built on top of the D3 and React libraries
 
 Tables / Data-Grids / Spreadsheets
 
-- [react-table](https://github.com/tannerlinsley/react-table/) - A lightweight, fast and extendable datagrid for React
-- [react-data-grid](https://github.com/adazzle/react-data-grid) - Excel-like grid component built with React
+- [react-table](https://www.npmjs.com/package/@tanstack/react-table) - A lightweight, fast and extendable datagrid for React
+- [react-data-grid](https://www.npmjs.com/package/react-data-grid) - Excel-like grid component built with React
 
 Spotlight / File Viewers / Carousels
 
-- [react-joyride](https://github.com/gilbarbara/react-joyride) - Create guided tours for your apps
-- [react-pdf-viewer](https://github.com/phuoc-ng/react-pdf-viewer) - A PDF viewer made for React
-- [swiper](https://github.com/nolimits4web/swiper) - modern mobile touch slider
+- [react-joyride](https://www.npmjs.com/package/react-joyride) - Create guided tours for your apps
+- [react-pdf-viewer](https://www.npmjs.com/package/@react-pdf-viewer/core) - A PDF viewer made for React
+- [swiper](https://npmjs.org/package/swiper) - modern mobile touch slider
 
 ## Misc
 
 Virtualization
 
 - [react-window](https://www.npmjs.com/package/react-window)
-- [tanstack-virtual](https://tanstack.com/virtual/v3)
+- [tanstack-virtual](https://www.npmjs.com/package/@tanstack/virtual-core)
 - [react-virtuoso](https://www.npmjs.com/package/react-virtuoso)
 
 Routing
 
-- [react-router](https://reactrouter.com/en/main)
-- [tanstack-router](https://tanstack.com/router/v1)
-- [reach-router](https://reach.tech/router/)
+- [react-router](https://www.npmjs.com/package/react-router-dom)
+- [tanstack-router](https://www.npmjs.com/package/@tanstack/router)
+- [reach-router](https://www.npmjs.com/package/@reach/router)
 - [wouter](https://www.npmjs.com/package/wouter)
 
 Internationalization (I18N)

--- a/src/pages/frameworks.mdx
+++ b/src/pages/frameworks.mdx
@@ -29,7 +29,7 @@ Everything in the rest of this article builds on top of React. Given today’s o
 
 For building mobile (iOS and Android) applications.
 
-You can also use a framework like [Expo](https://expo.dev/) to build an application that will run natively on Android, iOS, AND modern web browsers using the same codebase.
+You can also use a framework like [Expo](https://www.npmjs.com/package/expo) to build an application that will run natively on Android, iOS, AND modern web browsers using the same codebase.
 
 ## Next.js, Remix, Gatsby
 
@@ -44,24 +44,24 @@ Before you dive in below, you may benefit by watching [this video](https://www.y
 - Best for: static websites with infrequent content updates, fast content-driven websites, SEO-friendly sites
 - Not good if you need: dynamically generated pages (search results, user-generated feeds/content, application dashboards, etc.)
 - Tutorials
-    - [Official Gatsby Documentation](https://www.gatsbyjs.com/docs/tutorial/)
+  - [Official Gatsby Documentation](https://www.gatsbyjs.com/docs/tutorial/)
 
 **Next.js**
 
 - Best for: static websites, performant dynamic web apps/websites, SEO-friendly sites
 - Not good if you need: absolutely no requirement for server-side react or if your team has opinionated stances on functionality like routing, data fetching, etc.
 - Tutorials
-    - [Create a Next.js app - Official Next.js Documentation](https://nextjs.org/learn/basics/create-nextjs-app)
-    - [Introduction to Next.js 9](https://egghead.io/courses/introduction-to-next-js-9-9c01) - by Xiaoru Li
+  - [Create a Next.js app - Official Next.js Documentation](https://nextjs.org/learn/basics/create-nextjs-app)
+  - [Introduction to Next.js 9](https://egghead.io/courses/introduction-to-next-js-9-9c01) - by Xiaoru Li
 
 **Remix**
 
 - Best for: performant dynamic web apps/websites, SEO-friendly websites, progressive web features, BFFE (backend for front end)
 - Not good if you need: ??, framework maturity (TODO: honest breakdown of the fallbacks and negatives of Remix)
 - Tutorials:
-    - [Up and Running with Remix](https://egghead.io/courses/up-and-running-with-remix-b82b6bb6) - Kent C. Dodds
-    - [Remix Tutorial Livestream](https://www.youtube.com/watch?v=hsIWJpuxNj0) - Kent C. Dodds
-    - [Jokes App Tutorial](https://remix.run/docs/en/v1/tutorials/jokes) - Official Remix Documentation
+  - [Up and Running with Remix](https://egghead.io/courses/up-and-running-with-remix-b82b6bb6) - Kent C. Dodds
+  - [Remix Tutorial Livestream](https://www.youtube.com/watch?v=hsIWJpuxNj0) - Kent C. Dodds
+  - [Jokes App Tutorial](https://remix.run/docs/en/v1/tutorials/jokes) - Official Remix Documentation
 
 ## Framework Comparison
 
@@ -79,7 +79,7 @@ Further reading
 
 **Next vs Remix**
 
-Remix is something newer, attempting to take advantage of many current browser standards that can naturally make web applications more accessible and quicker across many devices and network capabilities. That was a jargony way of saying: *Remix really tries to make your app fast out of the box*. It's a bit of an unorthodox way of building a UI for your application needs, but the decisions are intentional. When comparing Remix to Next.js:
+Remix is something newer, attempting to take advantage of many current browser standards that can naturally make web applications more accessible and quicker across many devices and network capabilities. That was a jargony way of saying: _Remix really tries to make your app fast out of the box_. It's a bit of an unorthodox way of building a UI for your application needs, but the decisions are intentional. When comparing Remix to Next.js:
 
 - Both use file-system-based routing
 - Both take advantage of HTTP caching to deliver results to users as fast as possible

--- a/src/pages/hooks.mdx
+++ b/src/pages/hooks.mdx
@@ -41,9 +41,9 @@ Tips:
 
 - Read Dan Abramov's [Complete Guide to useEffect](https://overreacted.io/a-complete-guide-to-useeffect/) (and then, when you think you understand effects, read it again)
 - When effects run
-    - `useEffect(() ⇒ {})` - will run after every render of a component
-    - `useEffect(() ⇒ {}, [])` - will run only after the first render of a component
-    - `useEffect(() ⇒ {}, [deps])` - will run after renders, but only when deps change
+  - `useEffect(() ⇒ {})` - will run after every render of a component
+  - `useEffect(() ⇒ {}, [])` - will run only after the first render of a component
+  - `useEffect(() ⇒ {}, [deps])` - will run after renders, but only when deps change
 
 ## Advanced Hooks
 
@@ -57,5 +57,5 @@ Tips:
 
 You can also copy+paste hooks from the websites below into your own projects. If you prefer to keep npm dependencies as light as possible, you could copy over only the ones you need.
 
-- [usehooks.com](https://usehooks.com/)
-- [usehooks-ts.com](https://usehooks-ts.com/)
+- [usehooks.com](https://www.npmjs.com/package/use-hooks)
+- [usehooks-ts.com](https://www.npmjs.com/package/usehooks-ts)

--- a/src/pages/project-structure.mdx
+++ b/src/pages/project-structure.mdx
@@ -1,4 +1,5 @@
-export const description = 'How to structure your React project and format your components.'
+export const description =
+  'How to structure your React project and format your components.'
 
 # Project Standards for High-Quality Code
 
@@ -128,7 +129,7 @@ export function Calculator({left, operator, right}: CalculatorProps) {
    */
   useEffect(() => {
     // your effect code
-    
+
     return () => {
       // your effect cleanup code
     }
@@ -176,7 +177,7 @@ function ShortenedMarkup() {
 }
 ```
 
-[Eslint](https://eslint.org/) and [Prettier](https://prettier.io/) can also be very effective at enforcing project standards and consistency. Start with the examples provided in the bulletproof-react repo:
+[Eslint](https://www.npmjs.com/package/eslint) and [Prettier](https://www.npmjs.com/package/prettier) can also be very effective at enforcing project standards and consistency. Start with the examples provided in the bulletproof-react repo:
 
 - [.eslintrc.js](https://github.com/alan2207/bulletproof-react/blob/master/.eslintrc.js) (eslint config file)
 - [.prettierrc](https://github.com/alan2207/bulletproof-react/blob/master/.prettierrc) (prettier config file)
@@ -189,19 +190,19 @@ Getting engineers to properly document their code can sometimes be difficult (an
 
 The question typically isn't "how can we convince our team and stakeholders that well-written documentation is worth it". The right question to ask is "how can we make writing and maintaining documentation easier for our developers". Everyone knows great docs are worth their weight in gold. The hard part is writing great docs.
 
-1. Use [TypeScript](https://www.typescriptlang.org/) - TypeScript can create all sorts of documentation that your IDE (like [Visual Studio Code](https://code.visualstudio.com/docs/languages/typescript)) can display to you while coding. Using TypeScript properly means that all the engineers on your team can:
-    1. Analyze function signatures, parameters, and their return types without leaving the file you are working in
-    2. Autocomplete while typing, IntelliSense, etc.
-    3. Way more!
-2. [Storybook](https://storybook.js.org/) for components and UI libraries - leveraging something like Storybook makes it easier for team members to explore the various states/functionality of your reusable components. It also makes it easier to create entire design systems that can be used across your organization
-    - [Storybook for React Tutorial](https://storybook.js.org/tutorials/intro-to-storybook/react/en/get-started/)
-3. Commenting systems like [JSDoc](https://jsdoc.app/index.html) - technology like this assumes you write plentiful documentation in comments next to your code, and those same comments can be parsed to generate actual HTML webpages that you can navigate, view, etc. It basically tries to take all of your comments throughout your codebase and generate swagger-like documentation for it. If you did BOTH of the above options (1 and 2) this may not be necessary, but if one or both of the options above isn't viable for you then this may be helpful.
+1. Use [TypeScript](https://www.npmjs.com/package/typescript) - TypeScript can create all sorts of documentation that your IDE (like [Visual Studio Code](https://code.visualstudio.com/docs/languages/typescript)) can display to you while coding. Using TypeScript properly means that all the engineers on your team can:
+   1. Analyze function signatures, parameters, and their return types without leaving the file you are working in
+   2. Autocomplete while typing, IntelliSense, etc.
+   3. Way more!
+2. [Storybook](https://www.npmjs.com/package/storybook) for components and UI libraries - leveraging something like Storybook makes it easier for team members to explore the various states/functionality of your reusable components. It also makes it easier to create entire design systems that can be used across your organization
+   - [Storybook for React Tutorial](https://storybook.js.org/tutorials/intro-to-storybook/react/en/get-started/)
+3. Commenting systems like [JSDoc](https://www.npmjs.com/package/jsdoc) - technology like this assumes you write plentiful documentation in comments next to your code, and those same comments can be parsed to generate actual HTML webpages that you can navigate, view, etc. It basically tries to take all of your comments throughout your codebase and generate swagger-like documentation for it. If you did BOTH of the above options (1 and 2) this may not be necessary, but if one or both of the options above isn't viable for you then this may be helpful.
 
 You should at minimum be picking 1 option above. Or an approach that mixes all 3:
 
 - Using TypeScript
-    - Prevents an entire class of bugs from arising, and gives IDE more capabilities (Intellisense, auto-complete, etc.)
+  - Prevents an entire class of bugs from arising, and gives IDE more capabilities (Intellisense, auto-complete, etc.)
 - Using Storybook for all atomic/reusable components
-    - This would make it easy for engineers AND non-engineers peripheral to the project to browse the various components and their different states (centralized interactive design system)
+  - This would make it easy for engineers AND non-engineers peripheral to the project to browse the various components and their different states (centralized interactive design system)
 - Writing jsdoc-like comments above non-react functions that you define in your codebase
-    - Write jsdoc comments on functions defined that are NOT react components or something that returns JSX (utility functions, functions that are business/domain logic, data-fetching, etc.)
+  - Write jsdoc comments on functions defined that are NOT react components or something that returns JSX (utility functions, functions that are business/domain logic, data-fetching, etc.)

--- a/src/pages/styling.mdx
+++ b/src/pages/styling.mdx
@@ -3,21 +3,28 @@ export const description = 'The best ways to style your React application.'
 # Styling & UI Libraries
 
 <Note>
-    Helpful tip: before using any libraries below, you should check your IDE for plugins that might improve the developer experience of using it. For example, if you use Tailwind, the [Tailwind IntelliSense](https://marketplace.visualstudio.com/items?itemName=bradlc.vscode-tailwindcss) plugin (which recommends classnames in the auto-complete dropdown) and the [Headwind](https://marketplace.visualstudio.com/items?itemName=heybourn.headwind) plugin (enforces consistent ordering of classnames in my markup) in Visual Studio Code might be useful for your team.
+  Helpful tip: before using any libraries below, you should check your IDE for
+  plugins that might improve the developer experience of using it. For example,
+  if you use Tailwind, the [Tailwind
+  IntelliSense](https://marketplace.visualstudio.com/items?itemName=bradlc.vscode-tailwindcss)
+  plugin (which recommends classnames in the auto-complete dropdown) and the
+  [Headwind](https://marketplace.visualstudio.com/items?itemName=heybourn.headwind)
+  plugin (enforces consistent ordering of classnames in my markup) in Visual
+  Studio Code might be useful for your team.
 </Note>
 
 ## Styling Solutions
 
 - Utility Class Libraries
-    - [tailwindcss](https://tailwindcss.com/)
-    - [tachyons](https://tachyons.io/)
+  - [tailwindcss](https://www.npmjs.com/package/tailwindcss)
+  - [tachyons](https://www.npmjs.com/package/tachyons)
 - Write Your CSS
-    - [stitches](https://stitches.dev/)
-    - [styled-components](https://styled-components.com/)
-    - [vanilla-extract](https://github.com/seek-oss/vanilla-extract)
-    - [emotion](https://emotion.sh/docs/introduction)
-    - [CSS modules](https://github.com/css-modules/css-modules)
-    - [linaria](https://github.com/callstack/linaria)
+  - [stitches](https://www.npmjs.com/package/@stitches/react)
+  - [styled-components](https://www.npmjs.com/package/styled-components)
+  - [vanilla-extract](https://www.npmjs.com/package/@vanilla-extract/css)
+  - [emotion](https://www.npmjs.com/package/@emotion/css)
+  - [CSS modules](https://www.npmjs.com/package/css-modules)
+  - [linaria](https://www.npmjs.com/package/linaria)
 
 ## Component Libraries
 
@@ -25,29 +32,30 @@ Most UI libraries will come with a "theme" or global way to configure certain th
 
 If your app is small enough, it may be simpler to reach for a headless solution (more below) and create the critical components in your app than try to overwrite or customize an entire library.
 
-- [MUI](https://mui.com/)
-- [Twitter Bootstrap](https://react-bootstrap.github.io/)
-- [Chakra UI](https://chakra-ui.com/)
-- [AntDesign](https://ant.design/)
-- [Blueprint](https://blueprintjs.com/)
-- [FluentUI](https://react.fluentui.dev/?path=/docs/concepts-introduction--page)
-- [Mantine](https://mantine.dev/)
-- [pico](https://picocss.com/)
+- [MUI](https://www.npmjs.com/package/@mui/material)
+- [Twitter Bootstrap](https://www.npmjs.com/package/react-bootstrap)
+- [Chakra UI](https://www.npmjs.com/package/@chakra-ui/react)
+- [AntDesign](https://www.npmjs.com/package/antd)
+- [Blueprint](https://www.npmjs.com/package/@blueprintjs/core/)
+- [FluentUI](https://www.npmjs.com/package/@fluentui/react-components)
+- [Mantine](https://www.npmjs.com/package/@mantine/core)
+- [pico](https://www.npmjs.com/package/@picocss/pico)
 
 <Note>
-If you need a lot of customization or control over the presentation of the UI, you should consider a headless solution.
+  If you need a lot of customization or control over the presentation of the UI,
+  you should consider a headless solution.
 </Note>
 
 ## Headless Component Libraries
 
-- [radix-ui](https://www.radix-ui.com/)
-- [headless-ui](https://headlessui.com/)
+- [radix-ui](https://www.npmjs.com/package/@radix-ui/primitive)
+- [headless-ui](https://www.npmjs.com/package/@headlessui/react)
 - [react-aria](https://react-spectrum.adobe.com/react-aria/)
-- [reakit](https://reakit.io/)
+- [ariakit](https://www.npmjs.com/package/ariakit)
 
 ## Recommended Combinations
 
-- [Radix UI](https://www.radix-ui.com/) + [tailwind](https://tailwindcss.com/)
-- [Headless UI](https://headlessui.dev/) + [tailwind](https://tailwindcss.com/)
-- [Radix UI](https://www.radix-ui.com/) + [stitches](https://stitches.dev/)
-- [Chakra UI](https://chakra-ui.com/) + [emotion](https://emotion.sh/docs/introduction)
+- [Radix UI](https://www.npmjs.com/package/@radix-ui/primitive) + [tailwind](https://www.npmjs.com/package/tailwindcss)
+- [Headless UI](https://www.npmjs.com/package/@headlessui/react) + [tailwind](https://www.npmjs.com/package/tailwindcss)
+- [Radix UI](https://www.npmjs.com/package/@radix-ui/primitive) + [stitches](https://www.npmjs.com/package/@stitches/react)
+- [Chakra UI](https://www.npmjs.com/package/@chakra-ui/react) + [emotion](https://www.npmjs.com/package/@emotion/css)


### PR DESCRIPTION
I didn't change some of the links because they were showing a specific topic. For example:

*The authors [themselves have said](https://github.com/reactjs/reactjs.org/pull/5487#issuecomment-1409720741) they don't intend on adding new features or maintaining it much further*

Fixes #17 