### PR TITLE
fix: issue #56

### DIFF
--- a/src/components/QuickNavigation.jsx
+++ b/src/components/QuickNavigation.jsx
@@ -7,14 +7,14 @@ import { UserIcon } from '@/components/icons/UserIcon'
 const resources = [
   {
     href: '/javascript-basics',
-    name: 'JavaScript Basics',
+    name: 'JS / TS Fundamentals',
     description:
       'Starting points for developers not familiar with Javascript or Typescript.',
     icon: UserIcon,
   },
   {
     href: '/react-basics',
-    name: 'React Basics',
+    name: 'React Fundamentals',
     description:
       'For developers familiar with web development technologies (HTML, CSS, JS/TS) but not familiar with React.',
     icon: BookIcon,

--- a/src/pages/javascript-basics.mdx
+++ b/src/pages/javascript-basics.mdx
@@ -20,3 +20,16 @@ Our guides frequently make assumptions that you have worked with browser APIs (s
 - [The Odin Project](https://www.theodinproject.com/paths/full-stack-javascript) - full stack JavaScript development tutorial
 - [Egghead.io](https://egghead.io/courses/learn-es6-ecmascript-2015) - learn es6
 - [33 JS concepts](https://github.com/leonardomso/33-js-concepts) - 33 concepts every JavaScript developer should know
+
+## TypeScript
+
+A JavaScript (JS) developer can pick up the basics of TypeScript (TS) in about 10 minutes. But learning TS is more than just adding "types" to your variables here and there. It's about removing the possibility of a bug you'll probably run into if you wrote an application in pure JS. It's likely you already have an internal mental model of "data structures" when you're coding in JS - TypeScript just solidifies those mental models (in your head) into actual "rules" that can apply to your code and how it gets used.
+
+The class of bugs you're getting rid of are all those pesky (…cannot read… ‘undefined') errors in the console. If you're ready to get started, check out some of the links below:
+
+- [TS for the New Programmer](https://www.typescriptlang.org/docs/handbook/typescript-from-scratch.html) - TypeScript explained for beginners
+- [Beginner's TypeScript](https://www.totaltypescript.com/tutorials/beginners-typescript) - A (free) interactive video tutorial by Matt Pocock
+- [No BS TS](https://www.youtube.com/playlist?list=PLNqp92_EXZBJYFrpEzdO2EapvU0GOJ09n) - A (free) video course by Jack Herrington
+- [TypeScript errors](https://typescript.tv/errors/) - How to fix your confusing TypeScript errors
+
+It is not an exaggeration to call TypeScript an entire programming language, but even the simplest TypeScript can compile to JS. So the good news is you can adopt complexity only as it aids you. Sometimes you might have to temporarily level up or step outside your level of expertise to complete a feature. For example, if a library gives you code to work with and it's more advanced TS than you can ordinarily write, that's acceptable to use it. In most cases, adopting it incrementally in your JS projects and code is pretty painless.

--- a/src/pages/javascript-basics.mdx
+++ b/src/pages/javascript-basics.mdx
@@ -3,7 +3,7 @@ import { QuickNavigation } from '@/components/QuickNavigation'
 export const description =
   "Start here if you've never worked with JavaScript or TypeScript before."
 
-export const title = 'Basics of JavaScript'
+export const title = 'JavaScript / TypeScript Fundamentals'
 
 ## Learn JavaScript
 

--- a/src/pages/react-basics.mdx
+++ b/src/pages/react-basics.mdx
@@ -24,7 +24,7 @@ The class of bugs you're getting rid of are all those pesky (…cannot read… �
 - [TS for the New Programmer](https://www.typescriptlang.org/docs/handbook/typescript-from-scratch.html) - TypeScript explained for beginners
 - [Beginner's TypeScript](https://www.totaltypescript.com/tutorials/beginners-typescript) - A (free) interactive video tutorial by Matt Pocock
 - [No BS TS](https://www.youtube.com/playlist?list=PLNqp92_EXZBJYFrpEzdO2EapvU0GOJ09n) - A (free) video course by Jack Herrington
-- [Fix TypeScript errors](https://typescript.tv/errors/) - How to fix your confusing TypeScript errors
+- [TypeScript errors](https://typescript.tv/errors/) - How to fix your confusing TypeScript errors
 
 It is not an exaggeration to call TypeScript an entire programming language, but even the simplest TypeScript can compile to JS. So the good news is you can adopt complexity only as it aids you. Sometimes you might have to temporarily level up or step outside your level of expertise to complete a feature. For example, if a library gives you code to work with and it's more advanced TS than you can ordinarily write, that's acceptable to use it. In most cases, adopting it incrementally in your JS projects and code is pretty painless.
 

--- a/src/pages/react-basics.mdx
+++ b/src/pages/react-basics.mdx
@@ -24,7 +24,7 @@ The class of bugs you're getting rid of are all those pesky (…cannot read… �
 - [TS for the New Programmer](https://www.typescriptlang.org/docs/handbook/typescript-from-scratch.html) - TypeScript explained for beginners
 - [Beginner's TypeScript](https://www.totaltypescript.com/tutorials/beginners-typescript) - A (free) interactive video tutorial by Matt Pocock
 - [No BS TS](https://www.youtube.com/playlist?list=PLNqp92_EXZBJYFrpEzdO2EapvU0GOJ09n) - A (free) video course by Jack Herrington
-- https://typescript.tv/errors/ - How to fix your confusing TypeScript errors
+- [Fix TypeScript errors]https://typescript.tv/errors/ - How to fix your confusing TypeScript errors
 
 It is not an exaggeration to call TypeScript an entire programming language, but even the simplest TypeScript can compile to JS. So the good news is you can adopt complexity only as it aids you. Sometimes you might have to temporarily level up or step outside your level of expertise to complete a feature. For example, if a library gives you code to work with and it's more advanced TS than you can ordinarily write, that's acceptable to use it. In most cases, adopting it incrementally in your JS projects and code is pretty painless.
 

--- a/src/pages/react-basics.mdx
+++ b/src/pages/react-basics.mdx
@@ -24,6 +24,7 @@ The class of bugs you're getting rid of are all those pesky (…cannot read… �
 - [TS for the New Programmer](https://www.typescriptlang.org/docs/handbook/typescript-from-scratch.html) - TypeScript explained for beginners
 - [Beginner's TypeScript](https://www.totaltypescript.com/tutorials/beginners-typescript) - A (free) interactive video tutorial by Matt Pocock
 - [No BS TS](https://www.youtube.com/playlist?list=PLNqp92_EXZBJYFrpEzdO2EapvU0GOJ09n) - A (free) video course by Jack Herrington
+- https://typescript.tv/errors/ - How to fix your confusing TypeScript errors
 
 It is not an exaggeration to call TypeScript an entire programming language, but even the simplest TypeScript can compile to JS. So the good news is you can adopt complexity only as it aids you. Sometimes you might have to temporarily level up or step outside your level of expertise to complete a feature. For example, if a library gives you code to work with and it's more advanced TS than you can ordinarily write, that's acceptable to use it. In most cases, adopting it incrementally in your JS projects and code is pretty painless.
 

--- a/src/pages/react-basics.mdx
+++ b/src/pages/react-basics.mdx
@@ -24,7 +24,7 @@ The class of bugs you're getting rid of are all those pesky (…cannot read… �
 - [TS for the New Programmer](https://www.typescriptlang.org/docs/handbook/typescript-from-scratch.html) - TypeScript explained for beginners
 - [Beginner's TypeScript](https://www.totaltypescript.com/tutorials/beginners-typescript) - A (free) interactive video tutorial by Matt Pocock
 - [No BS TS](https://www.youtube.com/playlist?list=PLNqp92_EXZBJYFrpEzdO2EapvU0GOJ09n) - A (free) video course by Jack Herrington
-- [Fix TypeScript errors]https://typescript.tv/errors/ - How to fix your confusing TypeScript errors
+- [Fix TypeScript errors](https://typescript.tv/errors/) - How to fix your confusing TypeScript errors
 
 It is not an exaggeration to call TypeScript an entire programming language, but even the simplest TypeScript can compile to JS. So the good news is you can adopt complexity only as it aids you. Sometimes you might have to temporarily level up or step outside your level of expertise to complete a feature. For example, if a library gives you code to work with and it's more advanced TS than you can ordinarily write, that's acceptable to use it. In most cases, adopting it incrementally in your JS projects and code is pretty painless.
 

--- a/src/pages/react-basics.mdx
+++ b/src/pages/react-basics.mdx
@@ -15,19 +15,6 @@ What's covered here is typically high-level, the basics, or only a preview of wh
 
 It may be hard to avoid arguments over ideologies, clashes in opinions, or disagreements of philosophy, but this website will keep things civil! The main point is to surface the best ideas.
 
-## TypeScript
-
-A JavaScript (JS) developer can pick up the basics of TypeScript (TS) in about 10 minutes. But learning TS is more than just adding "types" to your variables here and there. It's about removing the possibility of a bug you'll probably run into if you wrote an application in pure JS. It's likely you already have an internal mental model of "data structures" when you're coding in JS - TypeScript just solidifies those mental models (in your head) into actual "rules" that can apply to your code and how it gets used.
-
-The class of bugs you're getting rid of are all those pesky (…cannot read… ‘undefined') errors in the console. If you're ready to get started, check out some of the links below:
-
-- [TS for the New Programmer](https://www.typescriptlang.org/docs/handbook/typescript-from-scratch.html) - TypeScript explained for beginners
-- [Beginner's TypeScript](https://www.totaltypescript.com/tutorials/beginners-typescript) - A (free) interactive video tutorial by Matt Pocock
-- [No BS TS](https://www.youtube.com/playlist?list=PLNqp92_EXZBJYFrpEzdO2EapvU0GOJ09n) - A (free) video course by Jack Herrington
-- [TypeScript errors](https://typescript.tv/errors/) - How to fix your confusing TypeScript errors
-
-It is not an exaggeration to call TypeScript an entire programming language, but even the simplest TypeScript can compile to JS. So the good news is you can adopt complexity only as it aids you. Sometimes you might have to temporarily level up or step outside your level of expertise to complete a feature. For example, if a library gives you code to work with and it's more advanced TS than you can ordinarily write, that's acceptable to use it. In most cases, adopting it incrementally in your JS projects and code is pretty painless.
-
 ## Why React?
 
 As a React enthusiast and the [author of the React Handbook](/team/eric-diviney), I often get asked why I like React more than other UI frameworks. I'll try to answer that below:

--- a/src/pages/react-basics.mdx
+++ b/src/pages/react-basics.mdx
@@ -3,7 +3,7 @@ import { QuickNavigation } from '@/components/QuickNavigation'
 export const description =
   "Start here if you've never worked with JavaScript or TypeScript before."
 
-export const title = 'Basics of React'
+export const title = 'Fundamentals of React'
 
 ## 👋 Hey, web devs
 


### PR DESCRIPTION
1. Successfully renamed "JavaScript Basics" to "JS / TS Fundamentals"
2. Changed the link title of the "javascript-basics.mdx" file to "JavaScript/TypeScript Fundamentals"
3. Successfully rename "React Basics" to "React Fundamentals"
4. Changed the link title of the "react-basics.mdx" file to "Fundamentals of React"
5. added this resource to the typescript resource list:
[typescript.tv/errors](https://typescript.tv/errors/) - how to fix your confusing TypeScript errors
6. Moved "typescript" resources from React Basics to JavaScript Basics 

resolves : issue #56