### PR TITLE
Fix reference to Material UI

### DIFF
--- a/src/pages/styling.mdx
+++ b/src/pages/styling.mdx
@@ -32,7 +32,7 @@ Most UI libraries will come with a "theme" or global way to configure certain th
 
 If your app is small enough, it may be simpler to reach for a headless solution (more below) and create the critical components in your app than try to overwrite or customize an entire library.
 
-- [MUI](https://www.npmjs.com/package/@mui/material)
+- [Material UI](https://www.npmjs.com/package/@mui/material)
 - [Twitter Bootstrap](https://www.npmjs.com/package/react-bootstrap)
 - [Chakra UI](https://www.npmjs.com/package/@chakra-ui/react)
 - [AntDesign](https://www.npmjs.com/package/antd)


### PR DESCRIPTION
The npm package linked is Material UI. MUI is the overall product suite & the organization name. Since the context reference to "general, the components render with opinionated styles already applied." it's not MUI we want to reference to. 

---

In the list of [Headless libraries](https://reacthandbook.dev/styling#headless-component-libraries), we have Base UI https://mui.com/base-ui, an isolation of the logic of Material UI. Is it worth adding? I can open a PR.

cc @samuelsycamore I landed here from https://react.statuscode.com/issues/353.