### PR TITLE
Refactor code for clarity and add .idea to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# idea
+.idea

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -19,6 +19,9 @@ const nextConfig = {
   experimental: {
     scrollRestoration: true,
   },
+  compiler: {
+    removeConsole: process.env.NODE_ENV === "production",
+  },
   async redirects() {
     return [
       {

--- a/src/components/Code.jsx
+++ b/src/components/Code.jsx
@@ -55,6 +55,12 @@ function CopyButton({ code }) {
       }
     }
   }, [copyCount])
+  
+  function copyToClipboard() {
+    window.navigator.clipboard.writeText(code).then(() => {
+      setCopyCount((count) => count + 1)
+    })
+  }
 
   return (
     <button
@@ -65,11 +71,7 @@ function CopyButton({ code }) {
           ? 'bg-sky-400/10 ring-1 ring-inset ring-sky-400/20'
           : 'bg-white/5 hover:bg-white/7.5 dark:bg-white/2.5 dark:hover:bg-white/5'
       )}
-      onClick={() => {
-        window.navigator.clipboard.writeText(code).then(() => {
-          setCopyCount((count) => count + 1)
-        })
-      }}
+      onClick={copyToClipboard}
     >
       <span
         aria-hidden={copied}

--- a/src/components/Details.tsx
+++ b/src/components/Details.tsx
@@ -58,6 +58,10 @@ export function Details({
 
   const buttonLabel = icon === 'contribute' ? 'What we need' : 'Read More';
 
+  function toggleOpen() {
+        setIsOpen(!isOpen)
+    }
+
   return (
     <div className="pt-8 my-8 bg-white shadow-lg pointer-events-auto dark:shadow-inset rounded-xl ring-1 ring-gray-900/10 dark:bg-zinc-900 dark:ring-zinc-800">
       <div className="px-8">
@@ -70,7 +74,7 @@ export function Details({
         <div className="pt-6 pb-2">
           <Button
             variant="filled"
-            onClick={() => setIsOpen(!isOpen)}
+            onClick={toggleOpen}
             arrow={isOpen ? 'up' : 'down'}
           >
             {isOpen ? 'Collapse' : buttonLabel}

--- a/src/components/Expand.jsx
+++ b/src/components/Expand.jsx
@@ -12,8 +12,8 @@ export function Expand({ children, parent }) {
     <div className="my-2">
       <div>
         <button
-          className="flex items-center gap-3 group"
-          onClick={() => toggleHidden()}
+          className="flex items-center text-left gap-3 group"
+          onClick={toggleHidden}
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -60,7 +60,7 @@ export function Layout({ children, sections = [] }) {
                   className={clsx(
                     'relative hidden h-6 w-6 lg:block transition-all text-zinc-800 dark:text-white'
                   )}
-                  onClick={() => toggleNavOpen()}
+                  onClick={toggleNavOpen}
                 >
                   <svg
                     xmlns="http://www.w3.org/2000/svg"

--- a/src/components/Tag.jsx
+++ b/src/components/Tag.jsx
@@ -8,11 +8,6 @@ const colorStyles = {
   sky: {
     small: 'text-sky-500 dark:text-sky-400',
     medium:
-      'ring-sky-300 dark:ring-sky-400/30 bg-sky-400/10 text-sky-500 dark:text-sky-400',
-  },
-  sky: {
-    small: 'text-sky-500',
-    medium:
       'ring-sky-300 bg-sky-400/10 text-sky-500 dark:ring-sky-400/30 dark:bg-sky-400/10 dark:text-sky-400',
   },
   amber: {


### PR DESCRIPTION
This commit addresses two main areas. Firstly, for improved code clarity and maintainability, redundant code blocks have been removed and onClick handlers have been refactored to separate functions rather than inline expressions. Secondly, the .idea directory (created by JetBrains IDEs like WebStorm or IntelliJ) has been added to the .gitignore file to avoid cluttering the repository with IDE settings.

closes #97