### PR TITLE
docs: get rid of first-person references

### DIFF
--- a/src/pages/about.mdx
+++ b/src/pages/about.mdx
@@ -6,11 +6,11 @@ export const description = 'About the React Handbook.'
 
 👋 Hey there
 
-My name is <Resource url='/team/eric-diviney/'>Eric</Resource>, and I created the initial version of this website I call the React Handbook.
+My name is <Resource url='/team/eric-diviney/'>Eric</Resource>, and I created the initial version of the React Handbook.
 
-**My goal for this website** is to cover the very nuanced details of working with React in production environments. 
+**The goal for this website** is to cover the very nuanced details of working with React in production environments. 
 
-I think this guide to opinionated React practices is necessary because the core React team can't and shouldn't focus too much of their time trying to cover the ecosystem in the docs (especially without showing favoritism).
+We believe this guide to opinionated React practices is necessary because the core React team can't and shouldn't focus too much of their time trying to cover the ecosystem in the docs (especially without showing favoritism).
 
 **What you might call this guide**
 - An opinionated guide to advanced React patterns and practices
@@ -22,7 +22,7 @@ If you're interested, you can help us by:
 
 1. **Validation that the topics covered and the recommended approaches generally are agreed upon as best practices by the community.** <br/> This is specifically helpful if you are an expert/experienced in a particular facet of development (styling/CSS as an example) - we are not looking for people to read in detail the entire website, but more like skip to the spots where YOU have expertise and explain what you would change (if anything)
 2. **Provide feedback for sections that are confusing, over-explained, or still not clear by the end of an article.** <br/> This is helpful from the exact opposite lens as point #1 above - if you are an expert in different facets of development than what is covered, but you really need to understand something you haven't ever dove into (testing or state-management for example) it's very helpful to get feedback when you still did not understand a topic very well after going through our material
-3. **Help out with small or large <Resource url='https://github.com/ericdiviney/react-handbook/issues'>issues</Resource> encountered in the maintenance of this website.** <br/> While we don't expect anyone to clean up the dirty work, we do keep track of smaller "tasks" or things that need to get done that might not require a seasoned/expert opinion and are just generally related more to site maintenance. If you're looking for more of those green squares in your GH profile but can't find things to work on, well I'd greatly appreciate it with these tasks. Some examples might be things like typos/spell-checks or text formatting, while others might be more interesting such as large component refactors (more realistic to professional React development).
+3. **Help out with small or large <Resource url='https://github.com/ericdiviney/react-handbook/issues'>issues</Resource> encountered in the maintenance of this website.** <br/> While we don't expect anyone to clean up the dirty work, we do keep track of smaller "tasks" or things that need to get done that might not require a seasoned/expert opinion and are just generally related more to site maintenance. If you're looking for more of those green squares in your GH profile but can't find things to work on, help with these tasks would be greatly appreciated. Some examples might be things like typos/spell-checks or text formatting, while others might be more interesting such as large component refactors (more realistic to professional React development).
 
 ---
 

--- a/src/pages/automated-testing.mdx
+++ b/src/pages/automated-testing.mdx
@@ -181,7 +181,7 @@ What to avoid when writing tests
     </Answer>
   </Question>
   <Question value='two'>
-    <QuestionText>What should I be mocking?</QuestionText>
+    <QuestionText>What types of things should be mocked in a test?</QuestionText>
     <Answer>
       - When we mock things, we say "Pretend this thing works perfectly, and pretend that in this particular test, the thing worked this particular way"
       - Great examples of things that should be mocked in most React app test suites:
@@ -192,7 +192,7 @@ What to avoid when writing tests
     </Answer>
   </Question>
   <Question value='three'>
-    <QuestionText>I'm using TypeScript. Do I still need to write unit tests?</QuestionText>
+    <QuestionText>Is writing unit tests necessary when using TypeScript?</QuestionText>
     <Answer>
       TypeScript does solve a basic level of testing in your application (in an automated way), yes. However, it is not sufficient to say that TS alone is enough to give you real confidence in your application code.
       

--- a/src/pages/frameworks/nextjs.mdx
+++ b/src/pages/frameworks/nextjs.mdx
@@ -38,7 +38,7 @@ Please consider <Resource url='https://github.com/ericdiviney/react-handbook/iss
 
 ## Why do people like using Next.js?
 
-This <Resource url='https://www.reddit.com/r/reactjs/comments/zprham/why_do_people_like_using_nextjs/'>reddit thread</Resource> is the inspiration for this section, and I'm going to summarize some of the responses here:
+This <Resource url='https://www.reddit.com/r/reactjs/comments/zprham/why_do_people_like_using_nextjs/'>reddit thread</Resource> is the inspiration for this section, and some of the responses are summarized here:
 
 1. The first and most upvoted response is one that appreciates the ease of maintenance in a project that supports Server-Side React rendering. It's not that the setup is hard - it's that the APIs and planning haven't all settled just yet and therefore as new updates get pushed and the features move along - maintenance and upkeep becomes a challenge.
 2. General consensus that the Next.js <Resource url='https://nextjs.org/docs'>documentation</Resource> is good

--- a/src/pages/state-management.mdx
+++ b/src/pages/state-management.mdx
@@ -393,7 +393,7 @@ Specific common overlaps between "App" State and "Session" State
 
 ### Thanks / References
 
-Thanks for reading! If you have any suggestions to make to how developers can approach managing state in their React applications <Resource url="/team/eric-diviney">I would love to talk with you</Resource> (and give you credit for your contributions!).
+Thanks for reading! If you have any suggestions on how developers can approach managing state in their React applications, <Resource url="/team/eric-diviney">let's talk</Resource> (You will get credit for your contributions!).
 - <Resource url='https://kentcdodds.com/blog/application-state-management-with-react'>kentcdodds.com/blog/application-state-management-with-react</Resource>
 - <Resource url='https://leerob.io/blog/react-state-management'>leerob.io/blog/react-state-management</Resource>
 - <Resource url='https://www.matillion.com/resources/blog/react-state-management-libraries-which-one'>matillion.com/resources/blog/react-state-management-libraries-which-one</Resource>

--- a/src/pages/styling.mdx
+++ b/src/pages/styling.mdx
@@ -9,7 +9,7 @@ export const description = 'The best ways to style your React application.'
   IntelliSense</Resource>
   plugin (which recommends classnames in the auto-complete dropdown) and the
   <Resource url='https://marketplace.visualstudio.com/items?itemName=heybourn.headwind'>Headwind</Resource>
-  plugin (enforces consistent ordering of classnames in my markup) in Visual
+  plugin (enforces consistent ordering of classnames in your markup) in Visual
   Studio Code might be useful for your team.
 </Note>
 


### PR DESCRIPTION
Rewrote some statements that heavily rely on using first-person pronoun.