### PR TITLE
fix: typo in url to clerk-react

### DIFF
--- a/src/pages/state-management.mdx
+++ b/src/pages/state-management.mdx
@@ -202,7 +202,7 @@ In almost all React apps that need authentication - the recommendation is to use
 
 - <Resource url='https://www.npmjs.com/package/@okta/okta-react'>okta-react</Resource>
 - <Resource url='https://www.npmjs.com/package/@auth0/auth0-react'>auth0-react</Resource>
-- <Resource url='ttps://www.npmjs.com/package/@clerk/clerk-react'>clerk-react</Resource>
+- <Resource url='https://www.npmjs.com/package/@clerk/clerk-react'>clerk-react</Resource>
 </Details>
 
 ## Common Uses of The Tools We Know


### PR DESCRIPTION
I noticed a typo in the URL to Clerk React while browsing the website. I've created a PR to address the issue.