### PR TITLE
Update styling.mdx

### DIFF
--- a/src/pages/styling.mdx
+++ b/src/pages/styling.mdx
@@ -7,9 +7,10 @@ export const description = 'The best ways to style your React application.'
   plugins that might improve the developer experience of using it. For example,
   if you use Tailwind, the <Resource url='https://marketplace.visualstudio.com/items?itemName=bradlc.vscode-tailwindcss'>Tailwind
   IntelliSense</Resource>
-  plugin (which recommends classnames in the auto-complete dropdown) and the
-  <Resource url='https://marketplace.visualstudio.com/items?itemName=heybourn.headwind'>Headwind</Resource>
-  plugin (enforces consistent ordering of classnames in your markup) in Visual
+  plugin (which recommends classnames in the auto-complete dropdown) and
+  <Resource url='https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode'>Prettier</Resource> coupled with the
+  <Resource url='https://github.com/tailwindlabs/prettier-plugin-tailwindcss'>Tailwind Prettier Plugin</Resource>
+  (enforces consistent ordering of classnames in your markup) in Visual
   Studio Code might be useful for your team.
 </Note>
 
@@ -21,7 +22,6 @@ export const description = 'The best ways to style your React application.'
 <Details icon='resources' label='More Tailwind Tips & Resources'>
   - Use the <Resource url='https://marketplace.visualstudio.com/items?itemName=moalamri.inline-fold'>inline fold</Resource> vscode plugin to collapse long className strings when you're not focused on them with the cursor - Inspired by <Resource url='https://twitter.com/housecor/status/1615790145751367712?s=20'>Cory House</Resource>
   - The <Resource url='https://marketplace.visualstudio.com/items?itemName=bradlc.vscode-tailwindcss'>Tailwind IntelliSense</Resource> vscode plugin gives you auto-complete
-  - The <Resource url='https://marketplace.visualstudio.com/items?itemName=heybourn.headwind'>Headwind</Resource> vscode plugin enforces consistent ordering of classnames markup
   - If you purchase <Resource url='https://tailwindui.com/'>tailwindui</Resource> you'll get access to tons of pre-made components + templates
   - <Resource url='https://ui.shadcn.com/'>shadcn/ui</Resource> - Open Source UI Components
   - <Resource url='https://preline.co/'>Preline</Resource> - Open Source UI Components


### PR DESCRIPTION
remove Headwind as it's [abandoned](https://github.com/heybourn/headwind/issues/185), added prettier + tailwind plugin as it's the [recommended official way](https://tailwindcss.com/blog/automatic-class-sorting-with-prettier) now.